### PR TITLE
Refactor TestGoPoolWithRetry to use atomic operations

### DIFF
--- a/gopool.go
+++ b/gopool.go
@@ -38,7 +38,7 @@ type goPool struct {
 	errorCallback func(error)
 	// adjustInterval is the interval to adjust the number of workers. Default is 1 second.
 	adjustInterval time.Duration
-	ctx    context.Context
+	ctx            context.Context
 	// cancel is used to cancel the context. It is called when Release() is called.
 	cancel context.CancelFunc
 }
@@ -57,8 +57,8 @@ func NewGoPool(maxWorkers int, opts ...Option) GoPool {
 		lock:           new(sync.Mutex),
 		timeout:        0,
 		adjustInterval: 1 * time.Second,
-		ctx:    ctx,
-		cancel: cancel,
+		ctx:            ctx,
+		cancel:         cancel,
 	}
 	// Apply options
 	for _, opt := range opts {


### PR DESCRIPTION
- Replaced the increment and read operations on taskRunCount with atomic.AddInt32 and atomic.LoadInt32 respectively in TestGoPoolWithRetry.
- This change ensures thread-safety when accessing taskRunCount, preventing potential data races.
- Also made minor formatting adjustments in gopool.go for better code readability.

fix #4 