### PR TITLE
Improve task execution and testing in goPool

### DIFF
--- a/gopool.go
+++ b/gopool.go
@@ -84,9 +84,17 @@ func (p *goPool) AddTask(t task) {
 	p.taskQueue <- t
 }
 
-// Wait waits for all tasks to be dispatched.
+// Wait waits for all tasks to be dispatched and completed.
 func (p *goPool) Wait() {
-	for len(p.taskQueue) > 0 {
+	for {
+		p.lock.Lock()
+		workerStackLen := len(p.workerStack)
+		p.lock.Unlock()
+
+		if len(p.taskQueue) == 0 && workerStackLen == len(p.workers) {
+			break
+		}
+
 		time.Sleep(100 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
- Modified the `executeTaskWithTimeout` function in `worker.go` to stop the task when the context is cancelled.
- Updated the `Wait` function in `gopool.go` to wait until all tasks are completed, not just dispatched.
- Added a new test case `TestGoPoolWithTimeout` in `gopool_test.go` to test the behavior of goPool when a task times out.
- Used the existing `lock` field in `goPool` to protect concurrent access to `workerStack` in `Wait` and `popWorker` functions.

fix #6