### PR TITLE
Add configurable task queue size to GoPool

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ ok  	github.com/devchat-ai/gopool	3.946s
 <img src="./logo/gopool.png" width="750">
 </div>
 
-- [x] **Task Queue**: GoPool uses a thread-safe task queue to store tasks waiting to be processed. Multiple workers can simultaneously fetch tasks from this queue.
+- [x] **Task Queue**: GoPool uses a thread-safe task queue to store tasks waiting to be processed. Multiple workers can simultaneously fetch tasks from this queue. The size of the task queue can be configured.
 
 - [x] **Concurrency Control**: GoPool can control the number of concurrent tasks to prevent system overload.
 
@@ -151,6 +151,35 @@ import (
 
 func main() {
     pool := gopool.NewGoPool(100, gopool.WithLock(new(spinlock.SpinLock)))
+    defer pool.Release()
+
+    for i := 0; i < 1000; i++ {
+        pool.AddTask(func() (interface{}, error){
+            time.Sleep(10 * time.Millisecond)
+            return nil, nil
+        })
+    }
+    pool.Wait()
+}
+```
+
+## Configurable Task Queue Size
+
+GoPool uses a thread-safe task queue to store tasks waiting to be processed. Multiple workers can simultaneously fetch tasks from this queue. The size of the task queue can be configured when creating the pool using the `WithTaskQueueSize` option.
+
+Here is an example of how to use GoPool with a configurable task queue size:
+
+```go
+package main
+
+import (
+    "time"
+
+    "github.com/devchat-ai/gopool"
+)
+
+func main() {
+    pool := gopool.NewGoPool(100, gopool.WithTaskQueueSize(5000))
     defer pool.Release()
 
     for i := 0; i < 1000; i++ {

--- a/README_zh.md
+++ b/README_zh.md
@@ -81,7 +81,7 @@ ok  	github.com/devchat-ai/gopool	3.946s
 <img src="./logo/gopool.png" width="750">
 </div>
 
-- [x] **任务队列**：GoPool 使用一个线程安全的任务队列来存储等待处理的任务。多个工作器可以同时从这个队列中获取任务。
+- [x] **任务队列**：GoPool 使用一个线程安全的任务队列来存储等待处理的任务。多个工作器可以同时从这个队列中获取任务。任务队列的大小可配置。
 
 - [x] **并发控制**：GoPool 可以控制并发任务的数量，防止系统过载。
 
@@ -151,6 +151,35 @@ import (
 
 func main() {
     pool := gopool.NewGoPool(100, gopool.WithLock(new(spinlock.SpinLock)))
+    defer pool.Release()
+
+    for i := 0; i < 1000; i++ {
+        pool.AddTask(func() (interface{}, error){
+            time.Sleep(10 * time.Millisecond)
+            return nil, nil
+        })
+    }
+    pool.Wait()
+}
+```
+
+## 配置任务队列大小
+
+GoPool 使用一个线程安全的任务队列来存储等待处理的任务。多个工作器可以同时从这个队列中获取任务。任务队列的大小可配置。可以通过在创建池时设置 `WithQueueSize` 选项来配置任务队列的大小。
+
+这是一个如何配置 GoPool 任务队列大小的示例：
+
+```go
+package main
+
+import (
+    "time"
+
+    "github.com/devchat-ai/gopool"
+)
+
+func main() {
+    pool := gopool.NewGoPool(100, gopool.WithTaskQueueSize(5000))
     defer pool.Release()
 
     for i := 0; i < 1000; i++ {

--- a/gopool_test.go
+++ b/gopool_test.go
@@ -129,4 +129,14 @@ var _ = Describe("Gopool", func() {
 			Expect(pool.GetWorkerCount()).To(Equal(minWorkers))
 		})
 	})
+
+	Describe("With TaskQueueSize", func() {
+		It("should work correctly", func() {
+			size := 5000
+			pool := gopool.NewGoPool(100, gopool.WithTaskQueueSize(size))
+			defer pool.Release()
+
+			Expect(pool.GetTaskQueueSize()).To(Equal(size))
+		})
+	})
 })

--- a/option.go
+++ b/option.go
@@ -50,3 +50,10 @@ func WithRetryCount(retryCount int) Option {
 		p.retryCount = retryCount
 	}
 }
+
+// WithTaskQueueSize sets the size of the task queue for the pool.
+func WithTaskQueueSize(size int) Option {
+	return func(p *goPool) {
+		p.taskQueueSize = size
+	}
+}


### PR DESCRIPTION
- Updated README.md and README_zh.md to reflect the new feature of configurable task queue size.
- Added a new field 'taskQueueSize' in the 'goPool' struct to store the size of the task queue.
- Modified the 'NewGoPool' function to initialize the task queue with the specified size.
- Added a new function 'GetTaskQueueSize' to return the size of the task queue.
- Updated the test file 'gopool_test.go' to include tests for the new feature.
- Added a new option 'WithTaskQueueSize' in 'option.go' to allow users to set the size of the task queue when creating the pool.